### PR TITLE
fix: [MM2-1333]

### DIFF
--- a/src/lib/data/cookies.ts
+++ b/src/lib/data/cookies.ts
@@ -52,7 +52,7 @@ export const setAuthToken = async (token: string) => {
   cookies.set('_medusa_jwt', token, {
     maxAge: 60 * 60 * 24 * 7,
     httpOnly: true,
-    sameSite: 'strict',
+    sameSite: 'lax',
     secure: process.env.NODE_ENV === 'production',
   });
 };


### PR DESCRIPTION
**Problem:**
Users clicking order confirmation links from emails were being redirected to the login page, even though they were already authenticated in another browser tab. This created a poor user experience.

**Root Cause:**
Authentication cookie (`_medusa_jwt`) was configured with `sameSite: 'strict'` attribute. This setting blocks cookies from being sent during cross-context navigations (e.g., clicking links from email clients), even when the request is to the same domain.

**Solution:**
Changed sameSite attribute from 'strict' to 'lax' in `setAuthToken` - `cookies.ts`:

Security Consideration:
The lax setting maintains strong security protections:
✅ Blocks CSRF attacks on POST/form submissions
✅ Prevents cookies from being sent in embedded frames (<iframe>)
✅ Only allows cookie transmission during top-level navigations (e.g., user clicking a link)
✅ This is the industry standard used by major platforms (Amazon, Shopify, GitHub, etc.)
✅ Default behavior in modern browsers (Chrome, Firefox, Safari)
The change improves UX for legitimate email-based navigation while maintaining protection against malicious cross-site requests.