### PR TITLE
MM2-2449 remove orders without order_set key

### DIFF
--- a/src/lib/data/orders.ts
+++ b/src/lib/data/orders.ts
@@ -115,6 +115,7 @@ export const listOrders = async (
         HttpTypes.StoreOrder & {
           seller: { id: string; name: string; reviews?: any[] };
           reviews: any[];
+          order_set: { id: string };
         }
       >;
     }>(`/store/orders`, {
@@ -131,7 +132,7 @@ export const listOrders = async (
       next,
       cache: 'no-cache'
     })
-    .then(({ orders }) => orders)
+    .then(({ orders }) => orders.filter(order => order.order_set))
     .catch(err => medusaError(err));
 };
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Behavior change in order listing**
> 
> - `listOrders` now requests `*order_set` and filters results to only include orders that have an `order_set`
> - Updates the order type to include `order_set: { id: string }` and adds `*order_set` to the `fields` query
> 
> This narrows returned data to valid order sets and aligns the response typing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c00843052c43b2b14a4905ac21e25fdb1051cb6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->